### PR TITLE
Make DefaultLLMModel use the repo member

### DIFF
--- a/src/llmmodels/basellmmodel.py
+++ b/src/llmmodels/basellmmodel.py
@@ -1,6 +1,6 @@
-from typing import Any, Protocol
+from typing import Protocol
 
 
 class BaseLLMModel(Protocol):
-    def generate_readme(self, **kwargs: Any) -> str:
+    def generate_readme(self) -> str:
         pass

--- a/src/llmmodels/defaultllmmodel.py
+++ b/src/llmmodels/defaultllmmodel.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict
 
 from langchain.chat_models import ChatOpenAI
 from langchain.prompts import BaseChatPromptTemplate, ChatPromptTemplate
@@ -19,7 +19,7 @@ from .basellmmodel import BaseLLMModel
 class DefaultLLMModel(BaseLLMModel):
     def __init__(
         self,
-        repo=BaseRepositoryAdapter,
+        repo: BaseRepositoryAdapter,
         config: DefaultLLMModelConfig = DefaultLLMModelConfig.get_default_config(),
     ):
         self.config = config
@@ -74,12 +74,10 @@ class DefaultLLMModel(BaseLLMModel):
             files_summaries[file] = summary
         return files_summaries
 
-    def generate_readme(
-        self, files_structure: List[str], files_contents: Dict[str, str]
-    ) -> str:
-        files_structure_text = get_files_structure_text(files_structure)
+    def generate_readme(self) -> str:
+        files_structure_text = get_files_structure_text(self.repo.repo_list())
 
-        files_summaries = self._get_files_summaries(files_contents)
+        files_summaries = self._get_files_summaries(self.repo.repo_files_contents())
         files_summaries_text = get_files_summaries_text(files_summaries)
 
         print("Generating README.md")

--- a/src/tests/test_llm_models.py
+++ b/src/tests/test_llm_models.py
@@ -6,6 +6,7 @@ from langchain.llms.fake import FakeListLLM
 from src.llmmodels.defaultllmmodel import DefaultLLMModel
 from src.tests.utils import get_resource_path, get_text_resource
 from src.utils.prompt import get_files_structure_text, get_files_summaries_text
+from src.repositoryadapters.defaultadapter import DefaultRepositoryAdapter
 
 
 class TestDefaultLLMModel(unittest.TestCase):
@@ -21,16 +22,29 @@ class TestDefaultLLMModel(unittest.TestCase):
         }
 
     @patch("src.llmmodels.defaultllmmodel.ChatOpenAI")
-    def test_get_prompt(self, mock_openAi):
+    @patch("src.repositoryadapters.defaultadapter.get_repo")
+    @patch("src.repositoryadapters.defaultadapter.get_files_list")
+    @patch("src.utils.repository.get_repo_ignored")
+    def test_get_prompt(
+        self, mock_get_repo_ignored, mock_get_files_list, mock_get_repo, mock_openAi
+    ):
         expected_prompt_path = get_resource_path("expected_prompt.txt")
         expected_prompt = get_text_resource(expected_prompt_path)
 
         mock_openAi.result_value = FakeListLLM(responses=["foo", "bar"])
 
+        mock_get_repo.return_value = "mocked repo"
+        mock_get_files_list.return_value = self.sample_file_structure
+        mock_get_repo_ignored.return_value = []
+
         file_structure_text = get_files_structure_text(self.sample_file_structure)
         files_summaries_text = get_files_summaries_text(self.sample_files_contents)
 
-        llm_model = DefaultLLMModel()
+        adapter = DefaultRepositoryAdapter(
+            "https://git-provider/owner/TestRepo", "/home/workspace"
+        )
+
+        llm_model = DefaultLLMModel(adapter)
         prompt_text = (
             llm_model._get_introduction_prompt()
             .format(
@@ -39,8 +53,6 @@ class TestDefaultLLMModel(unittest.TestCase):
             )
             .replace("Human: ", "")
         )
-        print(prompt_text)
-        print(expected_prompt)
         self.assertEqual(prompt_text, expected_prompt)
 
 

--- a/src/tests/test_llm_models.py
+++ b/src/tests/test_llm_models.py
@@ -1,12 +1,10 @@
 import unittest
 from unittest.mock import patch
 
-from langchain.llms.fake import FakeListLLM
-
 from src.llmmodels.defaultllmmodel import DefaultLLMModel
+from src.repositoryadapters.defaultadapter import DefaultRepositoryAdapter
 from src.tests.utils import get_resource_path, get_text_resource
 from src.utils.prompt import get_files_structure_text, get_files_summaries_text
-from src.repositoryadapters.defaultadapter import DefaultRepositoryAdapter
 
 
 class TestDefaultLLMModel(unittest.TestCase):
@@ -21,20 +19,26 @@ class TestDefaultLLMModel(unittest.TestCase):
             "TestRepo/file2.py": "File 2 contents",
         }
 
-    @patch("src.llmmodels.defaultllmmodel.ChatOpenAI")
+    def mock_get_file_content(self, file: str) -> str:
+        return self.sample_files_contents.get(file, "")
+
     @patch("src.repositoryadapters.defaultadapter.get_repo")
     @patch("src.repositoryadapters.defaultadapter.get_files_list")
+    @patch("src.repositoryadapters.defaultadapter.get_file_contents")
     @patch("src.utils.repository.get_repo_ignored")
     def test_get_prompt(
-        self, mock_get_repo_ignored, mock_get_files_list, mock_get_repo, mock_openAi
+        self,
+        mock_get_repo_ignored,
+        mock_get_file_contents,
+        mock_get_files_list,
+        mock_get_repo,
     ):
         expected_prompt_path = get_resource_path("expected_prompt.txt")
         expected_prompt = get_text_resource(expected_prompt_path)
 
-        mock_openAi.result_value = FakeListLLM(responses=["foo", "bar"])
-
         mock_get_repo.return_value = "mocked repo"
         mock_get_files_list.return_value = self.sample_file_structure
+        mock_get_file_contents.side_effect = self.mock_get_file_content
         mock_get_repo_ignored.return_value = []
 
         file_structure_text = get_files_structure_text(self.sample_file_structure)

--- a/src/utils/files.py
+++ b/src/utils/files.py
@@ -71,7 +71,7 @@ def get_file_contents(file_path: str) -> str:
 
 
 def get_relative_path(file_path: str, root_dir: str) -> str:
-    return file_path.replace(root_dir, "")[1:]
+    return file_path.replace(root_dir, "").removeprefix("/")
 
 
 def load_text_file(file_path: str) -> str:

--- a/src/utils/prompt.py
+++ b/src/utils/prompt.py
@@ -18,5 +18,6 @@ def get_files_summaries_text(files_summaries: Dict[str, str]) -> str:
     return text
 
 
-def execute_prompt(chain: Chain, **kwrags: Any):
-    return chain.invoke(kwrags)
+def execute_prompt(chain: Chain, **kwargs: Dict[str, Any]):
+    output = chain.invoke(kwargs)
+    return output


### PR DESCRIPTION
**Description:** The DefaultLLMModel’s generate_readme method is receiving the files list and files contents as parameters instead of using the ones provided by repo member.

**Expected Behavior:** DefaultLLMModel should be using the files list and contents from the repo member.

**Actual Behavior:** DefaultLLMModel is receiving the files and contents as parameters.