### PR TITLE
Add readme method to BaseRepositoryAdapter and DefaultRepositoryAdapter

### DIFF
--- a/src/repositoryadapters/baseadapter.py
+++ b/src/repositoryadapters/baseadapter.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Protocol, Tuple
+from typing import Any, Dict, List, Optional, Protocol, Tuple
 
 
 class BaseRepositoryAdapter(Protocol):
@@ -14,4 +14,7 @@ class BaseRepositoryAdapter(Protocol):
         pass
 
     def license(self) -> Tuple[str, str]:
+        pass
+
+    def readme(self) -> Optional[str]:
         pass

--- a/src/repositoryadapters/defaultadapter.py
+++ b/src/repositoryadapters/defaultadapter.py
@@ -9,6 +9,7 @@ from src.utils.files import (
 )
 from src.utils.repository import (
     get_license_type_from_file,
+    get_readme_file,
     get_repo,
     get_repo_license_file,
     get_repo_name_from_url,
@@ -77,3 +78,6 @@ class DefaultRepositoryAdapter(BaseRepositoryAdapter):
             self.repo_path, f"{self.repo_url}/blob/main"
         )
         return license_type, license_link
+
+    def readme(self) -> Optional[str]:
+        return get_readme_file(self.repo)

--- a/src/tests/test_adapters.py
+++ b/src/tests/test_adapters.py
@@ -89,6 +89,30 @@ class TestDefaultAdapter(unittest.TestCase):
 
         self.assertDictEqual(adapter.repo_files_contents(), expected_results)
 
+    @patch("src.repositoryadapters.defaultadapter.get_repo")
+    @patch("src.repositoryadapters.defaultadapter.get_readme_file")
+    def test_existing_readme(self, mock_get_readme_file, mock_get_repo):
+        mock_get_repo.return_value = "mocked repo"
+        mock_get_readme_file.return_value = "/home/workspace/TestRepo/README.md"
+
+        adapter = DefaultRepositoryAdapter(
+            "https://git-provider/owner/TestRepo", "/home/workspace"
+        )
+
+        self.assertTrue(adapter.readme())
+
+    @patch("src.repositoryadapters.defaultadapter.get_repo")
+    @patch("src.repositoryadapters.defaultadapter.get_readme_file")
+    def test_non_existing_readme(self, mock_get_readme_file, mock_get_repo):
+        mock_get_repo.return_value = "mocked repo"
+        mock_get_readme_file.return_value = None
+
+        adapter = DefaultRepositoryAdapter(
+            "https://git-provider/owner/TestRepo", "/home/workspace"
+        )
+
+        self.assertFalse(adapter.readme())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/utils/repository.py
+++ b/src/utils/repository.py
@@ -1,5 +1,4 @@
 import os
-from glob import glob
 from typing import List, Optional
 
 from git import Repo
@@ -46,14 +45,21 @@ def get_repo_non_ignored(repo: Repo, files_list: List[str]) -> List[str]:
     return [p for p in files_list if p not in ignored]
 
 
-def get_repo_license_file(repo: Repo) -> Optional[str]:
-    path = repo.working_tree_dir
-    pattern = os.path.join(path, "*LICENSE")
-    glob_output = glob(pattern)
-    if glob_output:
-        return glob_output[0]
+def search_file_in_repo_root(repo: Repo, filename: str) -> Optional[str]:
+    path = repo._working_tree_dir
+    file_path = os.path.join(path, filename)
+    if os.path.isfile(file_path):
+        return file_path
     else:
         return None
+
+
+def get_repo_license_file(repo: Repo) -> Optional[str]:
+    return search_file_in_repo_root(repo, "LICENSE")
+
+
+def get_readme_file(repo: Repo) -> Optional[str]:
+    return search_file_in_repo_root(repo, "README.md")
 
 
 def get_license_type_from_file(file_path: str) -> str:


### PR DESCRIPTION
**Description:** The BaseRepositoryAdapter is missing  the declaration of the readme method, which would return the README text of the repository if it exists.

**Expected Behavior:** BaseRepositoryAdapter should supply the readme method, which return the README text as a string. The method should raise an empty string if the repository is missing a README at the moment.

**Actual Behavior:** The method is missing.